### PR TITLE
fix: remove hard-coded paths from source code

### DIFF
--- a/src/apr/tests.rs
+++ b/src/apr/tests.rs
@@ -10,9 +10,12 @@ mod tests {
     #[test]
     #[cfg(feature = "cuda")]
     fn test_falsification_apr_cuda_gqa_dimensions() {
-        let apr_path = std::path::Path::new(
-            "/home/noah/.cache/huggingface/models/qwen2.5-coder-1.5b-apr/qwen2.5-coder-1.5b-q4k.apr"
+        let home = std::env::var("HOME").expect("HOME env var not set");
+        let apr_path_str = format!(
+            "{}/.cache/huggingface/models/qwen2.5-coder-1.5b-apr/qwen2.5-coder-1.5b-q4k.apr",
+            home
         );
+        let apr_path = std::path::Path::new(&apr_path_str);
 
         if !apr_path.exists() {
             println!("⚠️ Test model not available at {:?}, skipping", apr_path);

--- a/src/apr/tests_tensor_entry.rs
+++ b/src/apr/tests_tensor_entry.rs
@@ -388,9 +388,12 @@
     /// path will hang because GQA models will be treated as MHA.
     #[test]
     fn test_falsification_real_apr_file_num_kv_heads() {
-        let apr_path = std::path::Path::new(
-            "/home/noah/.cache/huggingface/models/qwen2.5-coder-1.5b-apr/qwen2.5-coder-1.5b-q4k.apr"
+        let home = std::env::var("HOME").expect("HOME env var not set");
+        let apr_path_str = format!(
+            "{}/.cache/huggingface/models/qwen2.5-coder-1.5b-apr/qwen2.5-coder-1.5b-q4k.apr",
+            home
         );
+        let apr_path = std::path::Path::new(&apr_path_str);
 
         if !apr_path.exists() {
             println!("⚠️ Test model not available at {:?}, skipping", apr_path);

--- a/src/cli/tests_12.rs
+++ b/src/cli/tests_12.rs
@@ -226,9 +226,10 @@ mod server_and_inference_tests {
         #[test]
         #[ignore = "requires real GGUF model file"]
         fn test_run_gguf_inference_real() {
+            let home = std::env::var("HOME").expect("HOME env var not set");
             let model_paths = [
-                "/home/noah/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
-                "/home/noah/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf",
+                format!("{}/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf", home),
+                format!("{}/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf", home),
             ];
 
             let model_path = model_paths
@@ -259,7 +260,8 @@ mod server_and_inference_tests {
         #[test]
         #[ignore = "requires real GGUF model file"]
         fn test_run_gguf_inference_json_output_real() {
-            let model_paths = ["/home/noah/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"];
+            let home = std::env::var("HOME").expect("HOME env var not set");
+            let model_paths = [format!("{}/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf", home)];
 
             let model_path = model_paths
                 .iter()

--- a/src/cli/tests_serve_model.rs
+++ b/src/cli/tests_serve_model.rs
@@ -335,9 +335,10 @@
     #[ignore = "requires real GGUF model file"]
     fn test_prepare_serve_state_gguf_success() {
         // Look for a test model file
+        let home = std::env::var("HOME").expect("HOME env var not set");
         let model_paths = [
-            "/home/noah/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
-            "/home/noah/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf",
+            format!("{}/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf", home),
+            format!("{}/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf", home),
         ];
 
         let model_path = model_paths
@@ -363,9 +364,10 @@
     #[tokio::test]
     #[ignore = "requires real GGUF model file"]
     async fn test_prepare_serve_state_gguf_batch() {
+        let home = std::env::var("HOME").expect("HOME env var not set");
         let model_paths = [
-            "/home/noah/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
-            "/home/noah/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf",
+            format!("{}/.apr/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf", home),
+            format!("{}/src/single-shot-eval/models/raw/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf", home),
         ];
 
         let model_path = model_paths

--- a/src/gguf/inference/forward/single_tests.rs
+++ b/src/gguf/inference/forward/single_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for single-token forward pass with KV cache
 //!
-//! Coverage target: /home/noah/src/realizar/src/gguf/inference/forward/single.rs
+//! Coverage target: src/gguf/inference/forward/single.rs
 //!
 //! Tests cover:
 //! - forward_single_with_cache: Main decode-phase forward pass

--- a/src/layers/tests/imp_086.rs
+++ b/src/layers/tests/imp_086.rs
@@ -309,8 +309,12 @@ fn test_imp_093_real_gguf_gpu_benchmark() {
     use std::time::Instant;
 
     // Real GGUF model path (Qwen 2.5 Coder 1.5B Q4_K_M)
-    let model_path =
-        "/home/noah/src/single-shot-eval/models/raw/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf";
+    let home = std::env::var("HOME").expect("HOME env var not set");
+    let model_path_str = format!(
+        "{}/src/single-shot-eval/models/raw/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf",
+        home
+    );
+    let model_path = &model_path_str;
 
     if !Path::new(model_path).exists() {
         eprintln!("IMP-093: Skipping - model not found at {}", model_path);


### PR DESCRIPTION
## Summary
- Replace 11 hard-coded `/home/noah` absolute paths in `src/` `.rs` files with `std::env::var("HOME")`-based portable alternatives
- One doc comment path changed from absolute to relative
- These paths break clean-room CI builds where the user is not `noah`

## Files changed
- `src/apr/tests.rs` — APR CUDA GQA test model path
- `src/apr/tests_tensor_entry.rs` — APR tensor entry test model path
- `src/cli/tests_12.rs` — GGUF inference integration test model paths (3 occurrences)
- `src/cli/tests_serve_model.rs` — serve state integration test model paths (2 occurrences)
- `src/layers/tests/imp_086.rs` — GPU benchmark test model path
- `src/gguf/inference/forward/single_tests.rs` — doc comment coverage target path

## Test plan
- [x] `cargo check` passes
- [ ] `clean-room / gate` CI passes (Mode A + Mode B)

Spec: sovereign-stack-protected-branch-strategy.md (Section 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)