### PR TITLE
fix: gate AVX-512 VNNI import for aarch64 cross-compile

### DIFF
--- a/src/quantize/parallel_k.rs
+++ b/src/quantize/parallel_k.rs
@@ -12,9 +12,9 @@
 
 use super::bsum_precompute::{fused_q4k_q8k_dot_with_bsums_simd, precompute_q8k_bsums};
 use super::format_trait::{Q5K, Q6K};
-use super::fused_k::{
-    fused_q4k_dot_simd, fused_q4k_q8k_dot_4rows_avx512vnni, fused_q4k_q8k_dot_simd,
-};
+use super::fused_k::{fused_q4k_dot_simd, fused_q4k_q8k_dot_simd};
+#[cfg(target_arch = "x86_64")]
+use super::fused_k::fused_q4k_q8k_dot_4rows_avx512vnni;
 use super::fused_q5k_q6k::{fused_q5k_dot_simd, fused_q6k_dot_simd};
 use super::generic_matvec::{generic_parallel_matvec, generic_parallel_matvec_into};
 use super::types::QK_K;

--- a/src/quantize/product.rs
+++ b/src/quantize/product.rs
@@ -115,6 +115,7 @@ impl InterleavedQ4K {
         self.dot_scalar(activations)
     }
 
+    /// Compute dot product using scalar fallback (non-x86_64).
     #[cfg(not(target_arch = "x86_64"))]
     pub fn dot(&self, activations: &[f32]) -> Result<f32> {
         self.dot_scalar(activations)


### PR DESCRIPTION
## Summary
- Gate `fused_q4k_q8k_dot_4rows_avx512vnni` import behind `#[cfg(target_arch = "x86_64")]`
- The function only exists on x86_64 — call sites were already gated, only the import was missing
- Blocks `cargo build --target aarch64-unknown-linux-gnu` for the entire realizar crate

## Test plan
- [x] `cargo check` passes on x86_64
- [ ] Cross-compile for `aarch64-unknown-linux-gnu` succeeds

Refs PMAT-035

🤖 Generated with [Claude Code](https://claude.com/claude-code)