### PR TITLE
fix: add aprender sibling checkout to nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,6 +78,21 @@ jobs:
         shell: pwsh
         run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
 
+      - name: Checkout aprender (path dep)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: paiml/aprender
+          path: aprender
+
+      - name: Symlink aprender for Cargo path deps
+        if: runner.os != 'Windows'
+        run: ln -sf "$GITHUB_WORKSPACE/aprender" "$GITHUB_WORKSPACE/../aprender"
+
+      - name: Symlink aprender (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\aprender" -Target "$env:GITHUB_WORKSPACE\aprender" -Force
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

- Adds checkout + symlink steps for `paiml/aprender` in the nightly workflow, matching the existing `provable-contracts` pattern
- Cargo requires path dependencies to exist at workspace resolution time, even when optional (`aprender = { version = ">=0.27", path = "../aprender", optional = true }`)
- Covers all 3 OS runners: Linux/macOS (symlink) and Windows (junction)

Refs realizar#207

## Test plan

- [ ] Trigger manual workflow dispatch and verify all 4 targets build successfully
- [ ] Confirm aprender checkout appears in build logs before `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)